### PR TITLE
Update to Paper 1.21.8; enable toolchain auto-download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     compileOnly('org.geysermc.geyser:api:2.7.1-SNAPSHOT')
     compileOnly('org.geysermc.floodgate:api:2.2.4-SNAPSHOT')
-    paperweight.paperDevBundle("1.21.5-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.8-R0.1-SNAPSHOT")
     compileOnly( "com.github.retrooper:packetevents-spigot:2.8.1-SNAPSHOT")
 }
 
@@ -52,7 +52,7 @@ tasks {
         dependsOn(tasks.reobfJar)
     }
     runServer {
-        minecraftVersion("1.21.5")
+        minecraftVersion("1.21.8")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx1g
+org.gradle.parallel=true
+org.gradle.daemon=true
+org.gradle.java.installations.auto-download=true
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = 'Geyser-Recipe-Fix'


### PR DESCRIPTION
- Bumped paperweight.paperDevBundle to 1.21.8 and runServer target to 1.21.8

- Added pluginManagement and Foojay resolver; enable toolchain auto-download in gradle.properties

- Build verified on 1.21.8 with Geyser/Floodgate/ProtocolLib/PacketEvents